### PR TITLE
Run tests also python 3.7 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
-sudo: false
+dist: xenial
 language: python
 python:
   - "3.5"
   - "3.6"
+  - "3.7"
 install: pip install tox-travis
 script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ envlist = py{35,36,37}, flake8, black
 python =
   3.5: py35
   3.6: py36,flake8,black
+  3.7: py37
 
 [testenv]
 deps=


### PR DESCRIPTION
This commit makes sure the tests are also run with python 3.7 in Travis.

For this it's necessary to add `dist: xenial` to `.travis.yml` and also remove
`sudo: false`.