### PR TITLE
fix(tests): fix i3ipc socket mock

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -96,7 +96,7 @@ def i3ipc_mock(mocker, tree_mock):
     mocker.patch.object(
         raiseorlaunch.i3ipc.Connection, "get_tree", return_value=tree_mock
     )
-    mocker.patch.object(i3ipc.socket.socket, "connect")
+    mocker.patch.object(i3ipc.connection.socket.socket, "connect")
 
 
 @pytest.fixture


### PR DESCRIPTION
Since version 2.0.1 of i3ipc we need to mock `socket.socket.connect` from
`i3ipc.connection` and not from `i3ipc`.

This commit fixed that.