### PR TITLE
fix: only listen to events if needed

### DIFF
--- a/raiseorlaunch/raiseorlaunch.py
+++ b/raiseorlaunch/raiseorlaunch.py
@@ -128,6 +128,14 @@ class Raiseorlaunch(object):
                     "Setting workspace and initial workspace is ambiguous!"
                 )
 
+    def _need_to_listen_to_events(self):
+        """
+        Evaluate if we need to listen to window events.
+
+        :return: bool
+        """
+        return any([self.scratch, self.con_mark, self.target_workspace])
+
     @staticmethod
     def _log_format_con(window):
         """
@@ -499,9 +507,12 @@ class Raiseorlaunch(object):
                 self.target_workspace or self.current_ws.name
             )
 
-        self.i3.on("window::new", self._callback_new_window)
+        if self._need_to_listen_to_events():
+            self.i3.on("window::new", self._callback_new_window)
         self.run_command()
-        self.i3.main(timeout=self.event_time_limit)
+
+        if self._need_to_listen_to_events():
+            self.i3.main(timeout=self.event_time_limit)
 
     def _callback_new_window(self, connection, event):
         """

--- a/tests/test_raiseorlaunch.py
+++ b/tests/test_raiseorlaunch.py
@@ -329,14 +329,19 @@ def test__handle_running_cycle(focused, match, Con, rol, mocker):
 
 
 @pytest.mark.parametrize(
-    "current_ws,target_ws,should_call_switch_ws",
-    [("ws1", "ws1", False), ("ws1", None, False), ("ws1", "ws2", True)],
+    "current_ws,target_ws,should_call_switch_ws,handle_event",
+    [
+        ("ws1", "ws1", False, True),
+        ("ws1", None, False, False),
+        ("ws1", "ws2", True, True),
+    ],
 )
 @pytest.mark.parametrize("leave_fullscreen", [True, False])
 def test__handle_not_running(
     current_ws,
     target_ws,
     should_call_switch_ws,
+    handle_event,
     leave_fullscreen,
     rol,
     Workspace,
@@ -370,9 +375,9 @@ def test__handle_not_running(
     else:
         assert not leave_fullscreen_on_workspace.called
 
-    assert on.called
+    assert on.called == handle_event
     assert run_command.called
-    assert main.called
+    assert main.called == handle_event
 
 
 @pytest.mark.parametrize("class1,class2", [("class1", "class2")])


### PR DESCRIPTION
Since we don't always move windows to desired workspaces (#38), there is
no need to always subscribe to window events.

This commit makes sure, we only subscribe to events if we really need
to.