### PR TITLE
chore(tests): temporary limit the maximum version of isort

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,8 @@ deps=
     pytest
     flake8
     flake8-isort
+    # can be removed, once flake8-isort dependency is resolved (https://github.com/gforcada/flake8-isort/issues/88)
+    isort<5
     flake8-bugbear
     flake8-comprehensions
 commands=flake8


### PR DESCRIPTION
This should be reverted once flake8-isort fixes the compatibility.