### PR TITLE
Fix TypeError when window class is None

### DIFF
--- a/raiseorlaunch/raiseorlaunch.py
+++ b/raiseorlaunch/raiseorlaunch.py
@@ -168,6 +168,8 @@ class Raiseorlaunch(object):
         Returns:
             bool: True for match, False otherwise.
         """
+        if string_to_match is None:
+            string_to_match = ""
         matchlist = [regex, string_to_match, *self.regex_flags]
         return True if re.match(*matchlist) else False
 

--- a/tests/test_raiseorlaunch.py
+++ b/tests/test_raiseorlaunch.py
@@ -89,6 +89,7 @@ def test__log_format_con(minimal_args, Con, mocker):
         ("qutebrowser", "Qutebrowser", False, False),
         ("^qutebrowser", "something_qutebrowser", False, True),
         ("^qutebrowser$", "qutebrowser_something", False, False),
+        ("qutebrowser", None, False, True),
     ],
 )
 def test__match_regex(minimal_args, ignore_case, regex, string, success, mocker):


### PR DESCRIPTION
If the window_class is empty the raiseorlaunch fails with the following error:
```
Traceback (most recent call last):
  File "/home/pedro/.local/bin/raiseorlaunch", line 8, in <module>
    sys.exit(main())
  File "/home/pedro/.local/pipx/venvs/raiseorlaunch/lib/python3.8/site-packages/raiseorlaunch/__main__.py", line 222, in main
    rol.run()
  File "/home/pedro/.local/pipx/venvs/raiseorlaunch/lib/python3.8/site-packages/raiseorlaunch/raiseorlaunch.py", line 547, in run
    running = self._is_running()
  File "/home/pedro/.local/pipx/venvs/raiseorlaunch/lib/python3.8/site-packages/raiseorlaunch/raiseorlaunch.py", line 242, in _is_running
    if self._compare_running(leave):
  File "/home/pedro/.local/pipx/venvs/raiseorlaunch/lib/python3.8/site-packages/raiseorlaunch/raiseorlaunch.py", line 181, in _compare_running
    if pattern and not self._match_regex(pattern, value):
  File "/home/pedro/.local/pipx/venvs/raiseorlaunch/lib/python3.8/site-packages/raiseorlaunch/raiseorlaunch.py", line 164, in _match_regex
    return True if re.match(*matchlist) else False
  File "/usr/lib/python3.8/re.py", line 191, in match
    return _compile(pattern, flags).match(string)
TypeError: expected string or bytes-like object
```
This fix prevents such error.