### PR TITLE
fix: only retain workspace_back_and_forth if workspace is set

### DIFF
--- a/raiseorlaunch/raiseorlaunch.py
+++ b/raiseorlaunch/raiseorlaunch.py
@@ -459,7 +459,10 @@ class Raiseorlaunch(object):
         if not window.focused:
             self.focus_window(window)
         else:
-            if self.current_ws.name == self.get_current_workspace().name:
+            if (
+                self.workspace
+                and self.current_ws.name == self.get_current_workspace().name
+            ):
                 logger.debug(
                     "We're on the right workspace. "
                     "Switching anyway to retain "

--- a/tests/test_raiseorlaunch.py
+++ b/tests/test_raiseorlaunch.py
@@ -283,6 +283,7 @@ def test__handle_running_no_scratch(
 
     window = Con(focused=focused)
 
+    rol.workspace = "ws"
     rol.current_ws = Workspace(name=current_ws_name)
     rol._handle_running_no_scratch(window)
 


### PR DESCRIPTION
If the `workspace` argument is provided, we can assume raiseorlaunch is
used as workspace switcher. Only then we should switch workspaces, when
the correct application is already focused.